### PR TITLE
User agent afterpay

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Afterpay.configure do |c|
   c.merchant_id = 'your_merchant_id'
   c.secret_key  = 'your_secret_key'
   c.server      = 'us_or_au_server' # Default is 'https://api.us.afterpay.com/'
+  c.user_agent  = 'MyAfterpayModule/1.0.0 (E-Commerce Platform Name/1.0.0; PHP/7.0.0; Merchant/600032000) https://merchant.example.com' # Default is nil
 end
 ```
 

--- a/lib/afterpay.rb
+++ b/lib/afterpay.rb
@@ -37,6 +37,11 @@ module Afterpay
     # @!attribute server
     attr_writer :server
 
+    # @!attribute user_agent
+    # @return [String] A User-Agent header must be supplied with all Merchant API requests prior to placing any live transactions.
+    # Create your User-Agent string here... https://developers.afterpay.com/afterpay-online/docs/user-agent-header-1
+    attr_accessor :user_agent
+
     # @yield [self] to accept configuration settings
     def configure
       yield self

--- a/lib/afterpay/http_service/request.rb
+++ b/lib/afterpay/http_service/request.rb
@@ -33,7 +33,13 @@ module Afterpay
       # Creates memoized Faraday::Connection instance
       # @return [Faraday::Connection] Faraday::Connection instance
       def adapter
-        @adapter ||= Faraday.new(server, {}, &middleware)
+        @adapter ||= Faraday.new(server, faraday_options, &middleware)
+      end
+
+      def faraday_options
+        return {} unless ::Afterpay.user_agent
+
+        { "headers" => { "User-Agent" => ::Afterpay.user_agent } }
       end
     end
   end

--- a/spec/api/configuration/retrieve_spec.rb
+++ b/spec/api/configuration/retrieve_spec.rb
@@ -7,7 +7,8 @@ describe Afterpay::API::Configuration::Retrieve do
     let(:type)           { 'PAY_BY_INSTALLMENT' }
     let(:minimum_amount) { build(:money) }
     let(:maximum_amount) { build(:money) }
-    let(:raw_response)   do
+    let(:user_agent) { "user_agent" }
+    let(:raw_response) do
       JSON.generate([{
                       type: type,
                       minimumAmount: minimum_amount,
@@ -16,12 +17,21 @@ describe Afterpay::API::Configuration::Retrieve do
     end
 
     before(:each) do
+      ::Afterpay.configure do |c|
+        c.user_agent = user_agent
+      end
+
       stub_request(:get, %r{api.us.afterpay.com/v2/configuration})
         .to_return(
           status: 200,
           body: raw_response,
           headers: { 'Content-Type' => 'application/json' }
         )
+    end
+
+    it 'makes request with the correct headers with the user_agent' do
+      expect(described_class.call).to have_requested(:get, "https://api.us.afterpay.com/v2/configuration").
+        with(headers: { "User-Agent" => user_agent })
     end
 
     it 'returns a list of payment configuration' do


### PR DESCRIPTION
# User Agent

Add the user agent to the configurations with default nil.

Add the attr_accessor for user_agent in the Afterpay so that other users can set up their user_agent.

Add `option_user_agent` method to return an empty hash if the user didn't set up a user_agent.


fix #16 