### PR TITLE
Upgrade the faraday and faraday-middleware gems to version ~> 1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_gem:
   relaxed-rubocop: .rubocop.yml
 
+AllCops:
+  TargetRubyVersion: 2.5
+
 Lint/MissingSuper:
   Enabled: false

--- a/afterpay.gemspec
+++ b/afterpay.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_runtime_dependency     'faraday',            '~> 0.15', '>= 0.15.3'
-  spec.add_runtime_dependency     'faraday_middleware', '~> 0.12', '>= 0.12.2'
+  spec.add_runtime_dependency     'faraday',            '~> 1.0'
+  spec.add_runtime_dependency     'faraday_middleware', '~> 1.0'
   spec.add_runtime_dependency     'hashie',             '~> 3.6',  '>= 3.6.0'
 
   spec.add_development_dependency 'bundler',            '~> 2.2.22'

--- a/afterpay.gemspec
+++ b/afterpay.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     'faraday',            '~> 1.0'
   spec.add_runtime_dependency     'faraday_middleware', '~> 1.0'
-  spec.add_runtime_dependency     'hashie',             '~> 3.6',  '>= 3.6.0'
+  spec.add_runtime_dependency     'hashie',             '~> 3.6', '>= 3.6.0'
 
   spec.add_development_dependency 'bundler',            '~> 2.2.22'
   spec.add_development_dependency 'codecov',            '~> 0.5.2'

--- a/lib/afterpay/http_service.rb
+++ b/lib/afterpay/http_service.rb
@@ -18,8 +18,7 @@ module Afterpay
     # Afterpay default middleware stack
     DEFAULT_MIDDLEWARE = proc do |builder|
       builder.request    :json
-
-      builder.basic_auth(*::Afterpay.configuration.values)
+      builder.request    :basic_auth, *::Afterpay.configuration.values
 
       builder.response   :mashify
       builder.response   :json, content_type: /\bjson$/


### PR DESCRIPTION
The gem was using a very old version of [faraday](https://github.com/lostisland/faraday) and [faraday-middleware](https://github.com/lostisland/faraday_middleware). This PR updates both gems to version `~> 1.0`.