### PR TITLE
Use the new Afterpay global-api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Merchant ID and Secret Key are required to work with Afterpay API
 Afterpay.configure do |c|
   c.merchant_id = 'your_merchant_id'
   c.secret_key  = 'your_secret_key'
-  c.server      = 'us_or_au_server' # Default is 'https://api.us.afterpay.com/'
+  c.server      = 'us_or_au_server' # Default is 'https://global-api.afterpay.com/'
   c.user_agent  = 'MyAfterpayModule/1.0.0 (E-Commerce Platform Name/1.0.0; PHP/7.0.0; Merchant/600032000) https://merchant.example.com' # Default is nil
 end
 ```

--- a/lib/afterpay.rb
+++ b/lib/afterpay.rb
@@ -62,5 +62,5 @@ module Afterpay
     end
   end
 
-  DEFAULT_SERVER = 'https://api.us.afterpay.com/'
+  DEFAULT_SERVER = 'https://global-api.afterpay.com/'
 end

--- a/spec/api/configuration/retrieve_spec.rb
+++ b/spec/api/configuration/retrieve_spec.rb
@@ -21,7 +21,7 @@ describe Afterpay::API::Configuration::Retrieve do
         c.user_agent = user_agent
       end
 
-      stub_request(:get, %r{api.us.afterpay.com/v2/configuration})
+      stub_request(:get, %r{global-api.afterpay.com/v2/configuration})
         .to_return(
           status: 200,
           body: raw_response,
@@ -30,7 +30,7 @@ describe Afterpay::API::Configuration::Retrieve do
     end
 
     it 'makes request with the correct headers with the user_agent' do
-      expect(described_class.call).to have_requested(:get, "https://api.us.afterpay.com/v2/configuration").
+      expect(described_class.call).to have_requested(:get, "https://global-api.afterpay.com/v2/configuration").
         with(headers: { "User-Agent" => user_agent })
     end
 

--- a/spec/api/order/create_spec.rb
+++ b/spec/api/order/create_spec.rb
@@ -12,7 +12,7 @@ describe Afterpay::API::Order::Create do
       let(:raw_response) { JSON.generate(token: token, expires: expires) }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/checkouts})
+        stub_request(:post, %r{global-api.afterpay.com/v2/checkouts})
           .to_return(
             status: 201,
             body: raw_response,
@@ -41,7 +41,7 @@ describe Afterpay::API::Order::Create do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/checkouts})
+        stub_request(:post, %r{global-api.afterpay.com/v2/checkouts})
           .to_return(
             status: 422,
             body: raw_response,

--- a/spec/api/payment/capture_spec.rb
+++ b/spec/api/payment/capture_spec.rb
@@ -11,7 +11,7 @@ describe Afterpay::API::Payment::Capture do
       let(:raw_response) { JSON.generate(id: '123') }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments})
           .to_return(
             status: 201,
             body: raw_response,
@@ -40,7 +40,7 @@ describe Afterpay::API::Payment::Capture do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments})
           .to_return(
             status: 422,
             body: raw_response,

--- a/spec/api/payment/deferred/auth_spec.rb
+++ b/spec/api/payment/deferred/auth_spec.rb
@@ -11,7 +11,7 @@ describe Afterpay::API::Payment::Auth do
       let(:raw_response) { JSON.generate(status: "APPROVED", paymentState: "AUTH_APPROVED") }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/auth})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/auth})
           .to_return(
             status: 201,
             body: raw_response,
@@ -40,7 +40,7 @@ describe Afterpay::API::Payment::Auth do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/auth})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/auth})
           .to_return(
             status: 402,
             body: raw_response,

--- a/spec/api/payment/deferred_capture_spec.rb
+++ b/spec/api/payment/deferred_capture_spec.rb
@@ -12,7 +12,7 @@ describe Afterpay::API::Payment::DeferredCapture do
       let(:raw_response) { JSON.generate(paymentState: 'PARTIALLY_CAPTURED') }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/#{order_id}/capture})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/#{order_id}/capture})
           .to_return(
             status: 201,
             body: raw_response,
@@ -42,7 +42,7 @@ describe Afterpay::API::Payment::DeferredCapture do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/#{order_id}/capture})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/#{order_id}/capture})
           .to_return(
             status: 412,
             body: raw_response,
@@ -71,7 +71,7 @@ describe Afterpay::API::Payment::DeferredCapture do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments//capture})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments//capture})
           .to_return(
             status: 404,
             body: raw_response,

--- a/spec/api/payment/find_spec.rb
+++ b/spec/api/payment/find_spec.rb
@@ -10,7 +10,7 @@ describe Afterpay::API::Payment::Find do
       let(:raw_response) { JSON.generate(paymentState: 'VOIDED') }
 
       before(:each) do
-        stub_request(:get, %r{api.us.afterpay.com/v2/payments/#{order_id}})
+        stub_request(:get, %r{global-api.afterpay.com/v2/payments/#{order_id}})
           .to_return(
             status: 201,
             body: raw_response,
@@ -40,7 +40,7 @@ describe Afterpay::API::Payment::Find do
       end
 
       before(:each) do
-        stub_request(:get, %r{api.us.afterpay.com/v2/payments/#{order_id}})
+        stub_request(:get, %r{global-api.afterpay.com/v2/payments/#{order_id}})
           .to_return(
             status: 404,
             body: raw_response,

--- a/spec/api/payment/refund_spec.rb
+++ b/spec/api/payment/refund_spec.rb
@@ -13,7 +13,7 @@ describe Afterpay::API::Payment::Refund do
       let(:raw_response) { JSON.generate(refundId: refund_id) }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/123/refund})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/123/refund})
           .to_return(
             status: 201,
             body: raw_response,
@@ -44,7 +44,7 @@ describe Afterpay::API::Payment::Refund do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/123/refund})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/123/refund})
           .to_return(
             status: 422,
             body: raw_response,

--- a/spec/api/payment/void_spec.rb
+++ b/spec/api/payment/void_spec.rb
@@ -12,7 +12,7 @@ describe Afterpay::API::Payment::Void do
       let(:raw_response) { JSON.generate(paymentState: 'VOIDED') }
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/#{order_id}/void})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/#{order_id}/void})
           .to_return(
             status: 201,
             body: raw_response,
@@ -42,7 +42,7 @@ describe Afterpay::API::Payment::Void do
       end
 
       before(:each) do
-        stub_request(:post, %r{api.us.afterpay.com/v2/payments/#{order_id}/void})
+        stub_request(:post, %r{global-api.afterpay.com/v2/payments/#{order_id}/void})
           .to_return(
             status: 404,
             body: raw_response,


### PR DESCRIPTION
Afterpay recently released a new unified endpoint for AU, NZ, US, CA, UK, FR, IT and ES.

https://afterpay-global-api.readme.io/reference/api-environments