### PR TITLE
Add the error_code to the BaseError

### DIFF
--- a/lib/afterpay/error_handler.rb
+++ b/lib/afterpay/error_handler.rb
@@ -11,11 +11,15 @@ module Afterpay
       def inspect(response)
         return response if response.ok?
 
-        raise ERRORS[response.status], response_message(response)
+        raise ERRORS[response.status].new(response_error_code(response)), response_message(response)
       end
 
       def response_message(response)
         response.body.is_a?(String) ? JSON.parse(response.body)['message'] : response.message
+      end
+
+      def response_error_code(response)
+        response.body.is_a?(String) ? JSON.parse(response.body)['errorCode'] : response.body.errorCode
       end
 
       ERRORS = {

--- a/lib/afterpay/errors.rb
+++ b/lib/afterpay/errors.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 module Afterpay
-  class BaseError                 < StandardError; end
+  class BaseError < StandardError
+    attr_accessor :error_code
+
+    def initialize(error_code)
+      super
+      @error_code = error_code
+    end
+  end
 
   class BadRequestError           < BaseError;     end
 

--- a/spec/error_handler_spec.rb
+++ b/spec/error_handler_spec.rb
@@ -5,8 +5,9 @@ require 'spec_helper'
 describe Afterpay::ErrorHandler do
   describe '.inspect' do
     let(:response)      { Object.new }
-    let(:error_body)    { "{\"error\":\"fail\"}" }
+    let(:error_body)    { "{\"message\":\"#{error_message}\", \"errorCode\":\"#{error_code}\"}" }
     let(:error_message) { 'failed request' }
+    let(:error_code)    { 'errorCode' }
 
     it 'returns a response if status is 200' do
       allow(response).to receive(:ok?)  { true }
@@ -25,7 +26,11 @@ describe Afterpay::ErrorHandler do
       it 'raises an error if status is not 200 and code is matched' do
         allow(response).to   receive(:status)  { 400 }
 
-        expect { described_class.inspect(response) }.to raise_error(Afterpay::BadRequestError)
+        expect { described_class.inspect(response) }.to raise_error(
+          an_instance_of(Afterpay::BadRequestError).and(
+            having_attributes(message: error_message, error_code: error_code)
+          )
+        )
       end
 
       it 'raises ServerError if code is not match' do


### PR DESCRIPTION
In this way the `error_code` returned by Afterpay can be retrieved in the
exception.