### PR TITLE
Add preorder attribute to item component

### DIFF
--- a/lib/afterpay/components/item.rb
+++ b/lib/afterpay/components/item.rb
@@ -43,6 +43,11 @@ module Afterpay
       # @return [String]
       # The estimated date when the order will be shipped, in YYYY-MM or YYYY-MM-DD format
       attr_accessor :estimated_shipment_date
+
+      # @attribute preorder
+      # @return boolean
+      # Should return false when the estimated_shipment_date is already passed otherwise true
+      attr_accessor :preorder
     end
   end
 end


### PR DESCRIPTION
This is needed when sending the estimated_shipment_date to
`Afterpay`, this should be false if the estimated shipment
date already passed otherwise it should return true.