### PR TITLE
Handle the RequestTimeout and GatewayTimeout errors

### DIFF
--- a/lib/afterpay/error_handler.rb
+++ b/lib/afterpay/error_handler.rb
@@ -36,7 +36,8 @@ module Afterpay
         422 => UnprocessableEntityError,
         429 => TooManyRequestsError,
         500 => InternalServerError,
-        503 => ServiceUnavailableError
+        503 => ServiceUnavailableError,
+        504 => GatewayTimeoutError
       }.freeze
     end
   end

--- a/lib/afterpay/error_handler.rb
+++ b/lib/afterpay/error_handler.rb
@@ -29,6 +29,7 @@ module Afterpay
         404 => NotFoundError,
         405 => MethodNotAllowedError,
         406 => NotAcceptableError,
+        408 => RequestTimeoutError,
         409 => ConflictError,
         410 => GoneError,
         412 => PreconditionFailedError,

--- a/lib/afterpay/errors.rb
+++ b/lib/afterpay/errors.rb
@@ -22,6 +22,8 @@ module Afterpay
 
   class NotAcceptableError        < BaseError;     end
 
+  class RequestTimeoutError       < BaseError;     end
+
   class ConflictError             < BaseError;     end
 
   class GoneError                 < BaseError;     end

--- a/lib/afterpay/errors.rb
+++ b/lib/afterpay/errors.rb
@@ -37,4 +37,6 @@ module Afterpay
   class InternalServerError       < BaseError;     end
 
   class ServiceUnavailableError   < BaseError;     end
+
+  class GatewayTimeoutError       < BaseError;     end
 end


### PR DESCRIPTION
This PR adds a new `RequestTimeoutError` and `GatewayTimeoutError` classes that are raised when the Afterpay server responds with `408 Request Timeout` or `504 Gateway Timeout`