### PR TITLE
Add extra properties to the Payment component to enable dynamic updates

### DIFF
--- a/lib/afterpay/components/payment.rb
+++ b/lib/afterpay/components/payment.rb
@@ -17,6 +17,28 @@ module Afterpay
       # @return [Afterpay::Components::Money]
       # The refund amount.
       attr_accessor :amount
+
+      # @attribute is_checkout_adjusted
+      # @return [Boolean]
+      # Whether there have been changes to the order since the initial order creation.
+      attr_accessor :is_checkout_adjusted
+
+      # @attribute payment_schedule_checksum
+      # @return [String]
+      # A unique value representing the payment schedule that must be provided
+      # when there has been changes since the initial order creation.
+      attr_accessor :payment_schedule_checksum
+
+      # @attribute items
+      # @return [Array<Afterpay::Components::Item>]
+      # An array of order items that have been updated to be provided
+      # if it has changed since the initial order creation.
+      attr_accessor :items
+
+      # @attribute shipping
+      # @return [Afterpay::Components::Contact]
+      # The shipping address for this order to be provided if it has changed since the initial order creation.
+      attr_accessor :shipping
     end
   end
 end


### PR DESCRIPTION
The Afterpay documentation for the [Express Checkout Payload (Capture Full Payment)](https://afterpay-global-api.readme.io/reference/express-checkout-payload-capture-full-payment) says:

In addition to the required amount field, you will also need to provide some extra properties to the payload if you are using the Afterpay Checkout Widget to enable dynamic updates to the order total on a review page (e.g. selecting shipping options, increasing item quantities, applying promo codes):

- `isCheckoutAdjusted`: the state to indicate if changes have been made since the initial order creation
- `items`: the list of order items if it has changed
- `shipping`: the shipping address if it has changed
- `paymentScheduleChecksum`: the latest paymentScheduleChecksum retrieved from your widget’s onChange call
